### PR TITLE
Add database integration testing to tallerDAO and citaDAO

### DIFF
--- a/branch-be/.gitignore
+++ b/branch-be/.gitignore
@@ -72,3 +72,4 @@ typings/
 # ts files
 /dist
 
+database.sqlite3

--- a/branch-be/src/adapter/citaAdapter.spec.ts
+++ b/branch-be/src/adapter/citaAdapter.spec.ts
@@ -497,8 +497,6 @@ describe("cita Adapter unit testing", () => {
         IdMecanico: 1,
       };
 
-      let result: any;
-
       before(async () => {
         getVehicleStub = sinon.stub(vehiculoDAO, "findOneByFilter");
         createCitaStub = sinon.stub(citaDAO, "create");
@@ -704,15 +702,9 @@ describe("cita Adapter unit testing", () => {
     });
 
     describe("cita update flow finishes succesfully", () => {
-      let updateStub: sinon.SinonStub<
-        [IdCita: string | number, cita: Partial<CitaCreationAttributes>],
-        Promise<[affectedCount: number]> | undefined
-      >;
+      let updateStub: sinon.SinonStub<[IdCita: number, cita: Partial<CitaCreationAttributes>], Promise<[affectedCount: number]>>;
 
-      let getCitaStub: sinon.SinonStub<
-        [IdCita: string | number],
-        Promise<CitaInstance | null> | undefined
-      >;
+      let getCitaStub: sinon.SinonStub<[IdCita: number], Promise<CitaInstance | null>>;
 
       let result: CitaInstance | null;
 
@@ -725,7 +717,7 @@ describe("cita Adapter unit testing", () => {
 
         updateStub.resolves([1]);
 
-        getCitaStub.resolves(mockGetById);
+        getCitaStub.resolves(mockGetById as CitaInstance);
 
         result = await citaAdapter.updateCitaByIdCita(1, citaUpdateMock);
       });
@@ -749,15 +741,9 @@ describe("cita Adapter unit testing", () => {
     });
 
     describe("cita state cancelled must not be update when fechaCita is less than 24h", () => {
-      let updateStub: sinon.SinonStub<
-        [IdCita: string | number, cita: Partial<CitaCreationAttributes>],
-        Promise<[affectedCount: number]> | undefined
-      >;
+      let updateStub: sinon.SinonStub<[IdCita: number, cita: Partial<CitaCreationAttributes>], Promise<[affectedCount: number]>>;
 
-      let getCitaStub: sinon.SinonStub<
-        [IdCita: string | number],
-        Promise<CitaInstance | null> | undefined
-      >;
+      let getCitaStub: sinon.SinonStub<[IdCita: number], Promise<CitaInstance | null>>;
 
       let result: any;
 
@@ -770,7 +756,7 @@ describe("cita Adapter unit testing", () => {
 
         updateStub.resolves([1]);
 
-        getCitaStub.resolves(mockGetById);
+        getCitaStub.resolves(mockGetById as CitaInstance);
 
         citaAdapter
           .updateCitaByIdCita(1, {
@@ -806,15 +792,9 @@ describe("cita Adapter unit testing", () => {
     });
 
     describe("must return error when getById cita is null", () => {
-      let updateStub: sinon.SinonStub<
-        [IdCita: string | number, cita: Partial<CitaCreationAttributes>],
-        Promise<[affectedCount: number]> | undefined
-      >;
+      let updateStub: sinon.SinonStub<[IdCita: number, cita: Partial<CitaCreationAttributes>], Promise<[affectedCount: number]>>;
 
-      let getCitaStub: sinon.SinonStub<
-        [IdCita: string | number],
-        Promise<CitaInstance | null> | undefined
-      >;
+      let getCitaStub: sinon.SinonStub<[IdCita: number], Promise<CitaInstance | null>>;
 
       let result: any;
 
@@ -861,15 +841,9 @@ describe("cita Adapter unit testing", () => {
     };
 
     describe("calification workshop is sent must update appointment succesfully", () => {
-      let updateStub: sinon.SinonStub<
-        [IdCita: string | number, cita: Partial<CitaCreationAttributes>],
-        Promise<[affectedCount: number]> | undefined
-      >;
+      let updateStub: sinon.SinonStub<[IdCita: number, cita: Partial<CitaCreationAttributes>], Promise<[affectedCount: number]>>;
 
-      let getCitaStub: sinon.SinonStub<
-        [IdCita: string | number],
-        Promise<CitaInstance | null> | undefined
-      >;
+      let getCitaStub: sinon.SinonStub<[IdCita: number], Promise<CitaInstance | null>>;
 
       let result: any;
 
@@ -882,7 +856,7 @@ describe("cita Adapter unit testing", () => {
 
         updateStub.resolves([1]);
 
-        getCitaStub.resolves(mockGetById);
+        getCitaStub.resolves(mockGetById as CitaInstance);
 
         result = await citaAdapter.calificaCitaByIdCita({
           IdCita: 1,
@@ -913,10 +887,7 @@ describe("cita Adapter unit testing", () => {
     });
 
     describe("must return error when any rate param are sent", () => {
-      let updateStub: sinon.SinonStub<
-        [IdCita: string | number, cita: Partial<CitaCreationAttributes>],
-        Promise<[affectedCount: number]> | undefined
-      >;
+      let updateStub: sinon.SinonStub<[IdCita: number, cita: Partial<CitaCreationAttributes>], Promise<[affectedCount: number]>>;
       let result: any;
 
       before(() => {
@@ -946,15 +917,9 @@ describe("cita Adapter unit testing", () => {
     });
 
     describe("update appointment database process fails exception must be returned", () => {
-      let updateStub: sinon.SinonStub<
-        [IdCita: string | number, cita: Partial<CitaCreationAttributes>],
-        Promise<[affectedCount: number]> | undefined
-      >;
+      let updateStub: sinon.SinonStub<[IdCita: number, cita: Partial<CitaCreationAttributes>], Promise<[affectedCount: number]>>;
 
-      let getCitaStub: sinon.SinonStub<
-        [IdCita: string | number],
-        Promise<CitaInstance | null> | undefined
-      >;
+      let getCitaStub: sinon.SinonStub<[IdCita: number], Promise<CitaInstance | null>>;
 
       let result: any;
 
@@ -967,7 +932,7 @@ describe("cita Adapter unit testing", () => {
 
         updateStub.rejects(new Error("Update appointment was not success"));
 
-        getCitaStub.resolves(mockGetById);
+        getCitaStub.resolves(mockGetById as CitaInstance);
 
         citaAdapter
           .calificaCitaByIdCita({ IdCita: 1, calificacion: 5 })
@@ -1001,14 +966,11 @@ describe("cita Adapter unit testing", () => {
   });
 
   describe("find By Filter functions", () => {
-    let findAllCitasByStub: sinon.SinonStub<
-      [
-        filterCita: WhereOptions<CitaAttributes>,
-        filterVehiculo: WhereOptions<VehiculoAttributes>,
-        filterOrden: WhereOptions<OrdenAttributes>
-      ],
-      Promise<CitaInstance[]> | undefined
-    >;
+    let findAllCitasByStub: sinon.SinonStub<[
+      filterCita?: WhereOptions<CitaAttributes> | undefined, 
+      filterVehiculo?: WhereOptions<VehiculoAttributes> | undefined, 
+      filterOrden?: WhereOptions<OrdenAttributes> | undefined], 
+    Promise<CitaInstance[]>>;
 
     const mockListAppointment = [
       {
@@ -1023,7 +985,7 @@ describe("cita Adapter unit testing", () => {
         estado: "Cancelada",
         fechaCita: new Date(),
       },
-    ];
+    ] as CitaInstance[];
 
     let result: CitaInstance[] | undefined;
 

--- a/branch-be/src/adapter/citaAdapter.ts
+++ b/branch-be/src/adapter/citaAdapter.ts
@@ -33,7 +33,7 @@ const findAll = () => citaDAO.findAll();
  * @param {*} IdCita
  * @param {*} cb
  */
-const findCitaByIdCita = (IdCita: string) => citaDAO.getById(IdCita);
+const findCitaByIdCita = (IdCita: number) => citaDAO.getById(IdCita);
 
 /**
  *
@@ -134,7 +134,7 @@ const createCita = (cita: CitaRequestAttributes) => {
 };
 
 const updateCitaByIdCita = (
-  IdCita: string | number,
+  IdCita: number,
   cita: CitaUpdateAttributes
 ) => {
   return new Promise<CitaInstance | null>((resolve, reject) => {
@@ -331,7 +331,7 @@ const countCitasByDateAndIdTaller = (IdTaller: string | number) => {
   );
 };
 
-const deleteById = (IdCita: string): Promise<number> | undefined =>
+const deleteById = (IdCita: number): Promise<number> =>
   citaDAO.deleteById(IdCita);
 
 export default {

--- a/branch-be/src/controller/citaController.ts
+++ b/branch-be/src/controller/citaController.ts
@@ -130,7 +130,7 @@ const updateCita = (req: Request, res: Response) => {
     delete cita.IdCita;
 
     citaAdapter
-      .updateCitaByIdCita(IdCita, cita)
+      .updateCitaByIdCita(parseInt(IdCita), cita)
       .then((cita) => {
         if (cita) {
           return res.status(HttpStatus.ACCEPTED).json({
@@ -164,7 +164,7 @@ const calificaCita = (req: Request, res: Response) => {
     const IdCita = req.params.Id;
     const { calificacion, calificacionUsuario } = req.body;
     citaAdapter
-      .calificaCitaByIdCita({ IdCita, calificacion, calificacionUsuario })
+      .calificaCitaByIdCita({ IdCita: parseInt(IdCita), calificacion, calificacionUsuario })
       .then((result) => {
         if (result) {
           return res.status(HttpStatus.ACCEPTED).json({
@@ -194,7 +194,7 @@ const deleteCitaById = (req: Request, res: Response) => {
     const IdCita = req.params.Id;
     console.debug("Parametro de IdCita recibido :::::>", IdCita);
     citaAdapter
-      .deleteById(IdCita)
+      .deleteById(parseInt(IdCita))
       ?.then((result) => {
         if (result) {
           return res.status(HttpStatus.ACCEPTED).json({
@@ -228,7 +228,7 @@ const findCitaById = (req: Request, res: Response) => {
     const IdCita = req.params.Id;
     //console.debug('Parametro de Idusuario recibido :::::>', req.params);
     citaAdapter
-      .findCitaByIdCita(IdCita)
+      .findCitaByIdCita(parseInt(IdCita))
       ?.then((cita) => {
         if (cita) {
           return res.status(HttpStatus.OK).json(cita);

--- a/branch-be/src/dao/citaDAO.spec.ts
+++ b/branch-be/src/dao/citaDAO.spec.ts
@@ -1,241 +1,236 @@
 import { expect } from "chai";
-import sinon from "sinon";
 import citaDAO from "./citaDAO";
-import { CitaModel } from "../database/models";
 import {
-  CountOptions,
-  CreateOptions,
-  DestroyOptions,
-  FindOptions,
-  Model,
-  Optional,
-  UpdateOptions,
-  WhereOptions,
+  Op,
 } from "sequelize";
 import {
-  CitaAttributes,
   CitaCreationAttributes,
+  CitaInstance,
+  TallerCreationAttributes,
+  TallerInstance,
+  UserCreationAttributes,
+  UserInstance,
+  VehiculoCreationAttributes,
+  VehiculoInstance,
 } from "../types";
+import { faker } from "@faker-js/faker";
+import tallerDAO from "./tallerDAO";
+import usersDAO from "./usersDAO";
+import vehiculoDAO from "./vehiculoDAO";
 
-describe.skip("cita DAO unit testing", () => {
-  describe("list cita functionality", () => {
-    let findAllStub: sinon.SinonStub<
-      [options?: FindOptions<any> | undefined],
-      Promise<Model<any, any>[]>
-    >;
-    beforeEach(() => {
-      findAllStub = sinon.stub(CitaModel, "findAll");
-    });
 
-    afterEach(() => {
-      findAllStub.restore();
-    });
+describe("cita DAO unit testing", () => {
 
-    it("cita model findAll result must be equal to findAll function", async () => {
-      const mockList = [{ id: 1 }, { id: 1 }, { id: 1 }];
-      findAllStub.resolves(mockList as any);
-      const list = await citaDAO.findAll();
+  let workshopResult: TallerInstance;
+  let vehicleResult: VehiculoInstance;
+  let vehicleResult2: VehiculoInstance;
+  let userResult: UserInstance;
+  let userResult2: UserInstance;
 
-      expect(list).to.have.lengthOf(mockList.length);
-    });
+  let appointmentCreated: CitaInstance;
+  let appointmentCreated2: CitaInstance;
+  let appointmentCreated3: CitaInstance;
+  let appointmentCreated4: CitaInstance;
 
-    it("cita model findAll function must be called", async () => {
-      findAllStub.resolves([]);
-      await citaDAO.findAll();
-
-      expect(findAllStub.called).to.equal(true);
-      expect(findAllStub.callCount).to.equal(1);
-    });
-
-    it("when cita model findAll function fails error is thrown upper layer", async () => {
-      findAllStub.rejects(new Error("Error getting list of citas"));
-      const stubCatch = sinon.spy();
-      const stubThen = sinon.spy();
-      await citaDAO.findAll().then(stubThen).catch(stubCatch);
-
-      expect(stubCatch.called).to.equal(true);
-      expect(stubThen.called).to.equal(false);
-    });
-  });
-
-  describe("create cita functionality", () => {
-    let createStub: sinon.SinonStub<
-      [
-        values?: Optional<any, string> | undefined,
-        options?: CreateOptions<any> | undefined
-      ],
-      Promise<Model<any, any>>
-    >;
-
-    const creationMock: CitaCreationAttributes = {
-      IdTaller: 1,
-      IdMecanico: 1,
-      IdVehiculo: 1,
-      fechaCita: new Date(),
-      horaCita: 12313,
-      servicio: "Test service",
-      estado: "Pendiente"
+  before(async ()=> {
+    const workshop: TallerCreationAttributes = {
+      nombre: faker.company.name(),
+      identificacion: faker.string.numeric(10),
+      email: faker.internet.email(),
+      celular: faker.phone.number(),
+      estado: faker.helpers.arrayElement(["Registrado", "Pendiente"]),
+      direccion: faker.location.streetAddress(),
+      latitude: faker.location.latitude(),
+      longitud: faker.location.longitude(),
+      telefono: faker.phone.number(),
+      logo: faker.image.url(),
     };
 
-    const result: CitaAttributes = {
-      ...creationMock,
-      IdCita: 1,
+    const user1: UserCreationAttributes = {
+      tipoUsuario: "Cliente" as const,
+      firstName: faker.person.firstName(),
+      email: faker.internet.email(),
+      estado: "Pendiente" as const,
+      celular: faker.phone.number(),
+      uid: faker.string.uuid()
     };
 
-    before(() => {
-      createStub = sinon.stub(CitaModel, "create");
-    });
-
-    after(() => {
-      createStub.restore();
-    });
-
-    it("cita model create function must be called when cita is created", async () => {
-      createStub.resolves(result as any);
-
-      const cita = await citaDAO.create(creationMock);
-
-      expect(createStub.called).to.equal(true);
-      expect(createStub.callCount).to.equal(1);
-
-      expect(cita).to.equal(result);
-    });
-
-    it("cita model create function must be called with specific params", async () => {
-      createStub.resolves(result as any);
-
-      await citaDAO.create(creationMock);
-
-      expect(createStub.calledWith(creationMock)).to.equal(true);
-    });
-  });
-
-  describe("update cita functionality", () => {
-    let updateStub: sinon.SinonStub<
-      [values: { [x: string]: any }, options: UpdateOptions<any>],
-      Promise<[affectedCount: number]>
-    >;
-
-    const toUpdate: Partial<CitaCreationAttributes> = {
-      IdMecanico: 1,
-      estado: "Attended"
+    const user2: UserCreationAttributes = {
+      tipoUsuario: "Cliente" as const,
+      firstName: faker.person.firstName(),
+      email: faker.internet.email(),
+      estado: "Pendiente" as const,
+      celular: faker.phone.number(),
+      uid: faker.string.uuid()
     };
 
-    const resultMock: [affectedCount: number] = [1];
-
-    beforeEach(() => {
-      updateStub = sinon.stub(CitaModel, "update");
-    });
-
-    afterEach(() => {
-      updateStub.restore();
-    });
-
-    it("citaModel update function result must be equal to citaDao update", async () => {
-      updateStub.resolves(resultMock);
-      const result = await citaDAO.update(1, toUpdate);
-
-      expect(result).to.equal(resultMock);
-    });
-
-    it("citaModel update function must be called when params is a number", async () => {
-      updateStub.resolves(resultMock);
-      await citaDAO.update(1, toUpdate);
-      expect(updateStub.called).to.equal(true);
-      expect(updateStub.callCount).to.equal(1);
-    });
-
-    it("citaModel update function must called once when param is an string", async () => {
-      updateStub.resolves(resultMock);
-      await citaDAO.update(1, toUpdate);
-      expect(updateStub.callCount).to.equal(1);
-    });
-  });
-
-  describe("delete cita functionality", () => {
-    let destroyStub: sinon.SinonStub<
-      [options?: DestroyOptions<any> | undefined],
-      Promise<number>
-    >;
-
-    beforeEach(() => {
-      destroyStub = sinon.stub(CitaModel, "destroy");
-    });
-
-    afterEach(() => {
-      destroyStub.restore();
-    });
-
-    it("citaModel destroy function result must be equal to deleteBy function", async () => {
-      destroyStub.resolves(1);
-      const result = await citaDAO.deleteById(1);
-      expect(result).to.equal(1);
-    });
-
-    it("tallerModel destroy function must be called when params is a number", async () => {
-      destroyStub.resolves(1);
-      await citaDAO.deleteById("1");
-      expect(destroyStub.called).to.equal(true);
-      expect(destroyStub.callCount).to.equal(1);
-    });
-  });
-
-  describe("count citas functionality", () => {
-    let countStub: sinon.SinonStub<
-      [options?: Omit<CountOptions<any>, "group"> | undefined],
-      Promise<number>
-    >;
-
-    const filter: WhereOptions<CitaAttributes> = {
-      estado: "Activa"
+    [workshopResult, userResult, userResult2] = await Promise.all([
+      tallerDAO.create(workshop),
+      usersDAO.create(user1),
+      usersDAO.create(user2)
+    ]);
+    
+    const createVehiculo: VehiculoCreationAttributes = {
+      IdTaller: workshopResult.IdTaller,
+      IdUsuario: userResult.uid || "",
+      IdMarca: 1,
+      estado: faker.helpers.arrayElement(["Registrado", "Pendiente"]),
+      placa: faker.vehicle.vrm(),
+      tipoVehiculo: faker.helpers.arrayElement(["Moto", "Carro"])
     };
 
-    beforeEach(() => {
-      countStub = sinon.stub(CitaModel, "count");
+    const createVehiculo2: VehiculoCreationAttributes = {
+      IdTaller: workshopResult.IdTaller,
+      IdUsuario: userResult2.uid || "",
+      IdMarca: 1,
+      estado: faker.helpers.arrayElement(["Registrado", "Pendiente"]),
+      placa: faker.vehicle.vrm(),
+      tipoVehiculo: faker.helpers.arrayElement(["Moto", "Carro"])
+    };
+
+    [vehicleResult, vehicleResult2] = await Promise.all([
+      vehiculoDAO.create(createVehiculo),
+      vehiculoDAO.create(createVehiculo2)
+    ]);
+  });
+
+
+  describe("create appointment", ()=> {
+
+    it("must fail when creates an appointment without the minimum values", async ()=> {
+      const appointment: any = {
+        IdTaller: workshopResult.IdTaller,
+        IdVehiculo: vehicleResult.IdVehiculo,
+        horaCita: 0,
+      };
+
+      await expect(citaDAO.create(appointment)).to.eventually.be.rejectedWith("cannot be null");
     });
 
-    afterEach(() => {
-      countStub.restore();
-    });
+    it("must create an appointment", async ()=> {
+      
+      const appointment: CitaCreationAttributes = {
+        IdTaller: workshopResult.IdTaller,
+        IdVehiculo: vehicleResult.IdVehiculo,
+        estado: "Solicitada",
+        fechaCita: faker.date.soon({ days: 2 }),
+        horaCita: 0,
+      };
 
-    it("cita model count function must be called when empty filters", async () => {
-      countStub.resolves(undefined);
+      const appointment2: CitaCreationAttributes = {
+        IdTaller: workshopResult.IdTaller,
+        IdVehiculo: vehicleResult.IdVehiculo,
+        estado: "Solicitada",
+        fechaCita: faker.date.soon({ days: 3 }),
+        horaCita: 0,
+      };
 
-      const result = await citaDAO.count({});
+      const appointment3: CitaCreationAttributes = {
+        IdTaller: workshopResult.IdTaller,
+        IdVehiculo: vehicleResult2.IdVehiculo,
+        estado: faker.helpers.arrayElement(["Confirmada", "Cancelada", "Incumplida"]),
+        fechaCita: faker.date.soon({ days: 9 }),
+        horaCita: 0,
+      };
 
-      expect(countStub.called).to.equal(true);
-      expect(countStub.callCount).to.equal(1);
+      const appointment4: CitaCreationAttributes = {
+        IdTaller: workshopResult.IdTaller,
+        IdVehiculo: vehicleResult2.IdVehiculo,
+        estado: faker.helpers.arrayElement(["Confirmada", "Cancelada", "Incumplida"]),
+        fechaCita: faker.date.soon({ days: 3 }),
+        horaCita: 0,
+      };
 
-      expect(result).to.equal(undefined);
-    });
+      [appointmentCreated, appointmentCreated2, appointmentCreated3, appointmentCreated4] = await Promise.all([
+        citaDAO.create(appointment),
+        citaDAO.create(appointment2),
+        citaDAO.create(appointment3),
+        citaDAO.create(appointment4),
+      ]);
 
-    it("cita model count function must be called when filter are set", async () => {
-      countStub.resolves(undefined);
-
-      const result = await citaDAO.count(
-        { IdTaller: "1" },
-        "IdVehiculo"
-      );
-
-      expect(countStub.called).to.equal(true);
-      expect(countStub.callCount).to.equal(1);
-
-      expect(result).to.equal(undefined);
-    });
-
-    it("cita model resolve function must be equal to citaDAO count result", async () => {
-      countStub.resolves(3);
-      const result = await citaDAO.count({});
-      expect(result).to.equal(3);
-    });
-
-    it("cita model resolve function must be equal to citaDAO count result when filters are set", async () => {
-      countStub.resolves(1);
-
-      const result = await citaDAO.count(filter, "IdCita");
-
-      expect(countStub.called).to.equal(true);
-      expect(result).to.equal(1);
+      expect(appointmentCreated).to.have.property("IdCita");
+      expect(appointmentCreated2).to.have.property("IdCita");
+      expect(appointmentCreated3).to.have.property("IdCita");
+      expect(appointmentCreated4).to.have.property("IdCita");
     });
   });
+
+  describe("get appointment by id", ()=> {
+    it("must return appointment found", async ()=> {
+      const appoinment = await citaDAO.getById(appointmentCreated.IdCita);
+      expect(appoinment).to.have.property("IdCita");
+      expect(appoinment?.taller).not.to.be.null;
+      expect(appoinment?.vehiculo).not.to.be.null;
+    });
+
+    it("must return null when appointment is not found", async ()=> {
+      await expect(citaDAO.getById(-1)).to.eventually.be.null;
+    });
+  });
+
+  describe("get appointments by filter", ()=> {
+    it("must return empty when appoinments are not found by filters received", async ()=> {
+      const appointments = await citaDAO.findAllByFilter({ IdMecanico: {
+        [Op.not]: null
+      }});
+      expect(appointments).to.be.empty;
+    });
+
+    it("must return all the appointments when no filters are received", async ()=> {
+      const appointments = await citaDAO.findAllByFilter();
+      expect(appointments).to.have.length(4);
+    });
+
+    it("must search appointments with appoinment filter", async ()=> {
+      const appointments = await citaDAO.findAllByFilter({ estado: "Solicitada" ,  IdTaller: workshopResult.IdTaller });
+      expect(appointments).to.have.length(2);
+    });
+
+    it("must filter appointments using vehicle filter", async()=> {
+      const appointments = await citaDAO.findAllByFilter({}, { IdUsuario: userResult.uid });
+      expect(appointments).to.have.length(2);
+    });
+  });
+
+  describe("count appointments", ()=> {
+    it("count all the appoinments when filter is not received", async ()=> {
+      const amountOfAppointments = await citaDAO.count();
+      expect(amountOfAppointments).to.be.equal(4);
+    });
+
+    it("must filter appointments", async ()=> {
+      const amountOfAppointments = await citaDAO.count({ estado: "Solicitada" });
+      expect(amountOfAppointments).to.be.equal(2);
+    });
+
+    it("must count appointments grouped by", async ()=> {
+      const amountOfAppointments = await citaDAO.count({}, "IdTaller", ["IdTaller"]);
+      expect(amountOfAppointments).to.deep.equal([{ count: 4, IdTaller: workshopResult.IdTaller }]);
+    });
+  });
+
+  describe("update appointment", ()=> {
+    it("update appoinment by filter", async()=> {
+      const updatedAppointment = await citaDAO.update(appointmentCreated2.IdCita, { estado: "Confirmada" });
+      expect(updatedAppointment).to.deep.equal([1]);
+    });
+
+    it("must return zero items updated when the appointment to update does not exist", async()=> {
+      const updatedAppointment = await citaDAO.update(-1, { estado: "Confirmada" });
+      expect(updatedAppointment).to.deep.equal([0]);
+    });
+  });
+
+  describe("delete appointment", ()=> {
+    it("must delete existing appointment", async ()=> {
+      const result = await citaDAO.deleteById(appointmentCreated4.IdCita);
+      expect(result).to.be.equal(1);
+    });
+
+    it("must return zero when appointment does not exist", async ()=> {
+      const result = await citaDAO.deleteById(-1);
+      expect(result).to.be.equal(0);
+    });
+  });
+
 });

--- a/branch-be/src/dao/citaDAO.ts
+++ b/branch-be/src/dao/citaDAO.ts
@@ -23,111 +23,101 @@ import {
 
 const findAll = (): Promise<CitaInstance[]> => CitaModel.findAll();
 
-const create = (cita: CitaCreationAttributes): Promise<CitaInstance> | undefined => {
-  // Find all users
-  return CitaModel.sequelize?.transaction(() => {
-    return CitaModel.create(cita).then((cita) => {
-      return cita;
-    });
+const create = (cita: CitaCreationAttributes): Promise<CitaInstance> => {
+  return CitaModel.create(cita).then((cita) => {
+    return cita;
   });
 };
 
 const update = (
-  IdCita: string | number,
+  IdCita: number,
   cita: Partial<CitaCreationAttributes>
-): Promise<[affectedCount: number]> | undefined => {
-  // Find all users
-  return CitaModel.sequelize?.transaction((t1) => {
-    return CitaModel.update(cita, {
-      where: { IdCita: IdCita },
-    });
+): Promise<[affectedCount: number]> => {
+  return CitaModel.update(cita, {
+    where: { IdCita: IdCita },
   });
 };
 
-const getById = (IdCita: string | number): Promise<CitaInstance | null> | undefined => {
-  // Find all users
-  return CitaModel.sequelize?.transaction((t1) => {
-    return CitaModel.findByPk(IdCita, {
-      include: [
-        {
-          model: VehiculoModel,
-          include: [
-            {
-              model: MarcaModel,
-            },
-            {
-              model: UserModel,
-            },
-          ],
-        },
-        {
-          model: TallerModel,
-        },
-        {
-          model: MecanicoModel,
-        },
-      ],
-    });
+const getById = (IdCita: number): Promise<CitaInstance | null> => {
+  return CitaModel.findByPk(IdCita, {
+    include: [
+      {
+        model: VehiculoModel,
+        include: [
+          {
+            model: MarcaModel,
+            required: true
+          },
+          {
+            model: UserModel,
+            required: true
+          },
+        ],
+      },
+      {
+        model: TallerModel,
+        required: true,
+      },
+      {
+        model: MecanicoModel,
+      },
+    ],
   });
 };
 
-const deleteById = (IdCita: string | number): Promise<number> | undefined => {
-  // Find all users
-  return CitaModel.sequelize?.transaction((t1) => {
-    return CitaModel.destroy({
-      where: { IdCita: IdCita },
-    }).then((deleted) => {
-      return deleted;
-    });
+const deleteById = (IdCita: number): Promise<number> => {
+  return CitaModel.destroy({
+    where: { IdCita: IdCita },
   });
 };
 
 const findAllByFilter = (
-  filterCita: WhereOptions<CitaAttributes>,
-  filterVehiculo: WhereOptions<VehiculoAttributes>,
-  filterOrden: WhereOptions<OrdenAttributes>
-): Promise<CitaInstance[]> | undefined => {
-  // Find all users
-  return CitaModel.sequelize?.transaction((t1) => {
-    return CitaModel.findAll({
-      include: [
-        {
-          model: VehiculoModel,
-          where: filterVehiculo,
-          include: [
-            {
-              model: MarcaModel,
-            },
-            {
-              model: UserModel,
-            },
-          ],
-        },
-        {
-          model: TallerModel,
-        },
-        {
-          model: MecanicoModel,
-        },
-        {
-          model: OrdenModel,
-          where: filterOrden,
-          include: [
-            {
-              model: MecanicoModel,
-              required: false,
-            },
-          ],
-          required: false,
-        },
-      ],
-      where: filterCita,
-      order: [
-        ["fechaCita", "DESC"],
-        ["horaCita", "DESC"],
-        [OrdenModel, "IdEtapa"],
-      ],
-    });
+  filterCita: WhereOptions<CitaAttributes> = {},
+  filterVehiculo: WhereOptions<VehiculoAttributes> = {},
+  filterOrden: WhereOptions<OrdenAttributes> = {}
+): Promise<CitaInstance[]> => {
+  return CitaModel.findAll({
+    include: [
+      {
+        model: VehiculoModel,
+        required: true,
+        where: filterVehiculo,
+        include: [
+          {
+            model: MarcaModel,
+            required: true
+          },
+          {
+            model: UserModel,
+            required: true
+          },
+        ],
+      },
+      {
+        model: TallerModel,
+        required: true
+      },
+      {
+        model: MecanicoModel,
+      },
+      {
+        model: OrdenModel,
+        where: filterOrden,
+        include: [
+          {
+            model: MecanicoModel,
+            required: false,
+          },
+        ],
+        required: false,
+      },
+    ],
+    where: filterCita,
+    order: [
+      ["fechaCita", "DESC"],
+      ["horaCita", "DESC"],
+      [OrdenModel, "IdEtapa"],
+    ],
   });
 };
 
@@ -135,23 +125,22 @@ const count = (
   filter?: WhereOptions<CitaAttributes>,
   groupBy?: GroupOption,
   attributes?: FindAttributeOptions
-): Promise<GroupedCountResultItem[]> | Promise<number> | undefined => {
-  // Find all users
+): Promise<GroupedCountResultItem[]> | Promise<number> => {
   if (groupBy) {
-    return CitaModel.sequelize?.transaction((t1) => {
-      return CitaModel.count({
-        group: groupBy,
-        attributes: attributes,
-        where: filter,
-      });
+    return CitaModel.count({
+      group: groupBy,
+      attributes: attributes,
+      where: filter,
     });
   } else {
-    return CitaModel.sequelize?.transaction((t1) => {
-      return CitaModel.count({
-        where: filter,
-      });
+    return CitaModel.count({
+      where: filter,
     });
   }
+};
+
+const truncate = async (): Promise<void> => {
+  await CitaModel.truncate({ restartIdentity: true });
 };
 
 export default {
@@ -161,5 +150,6 @@ export default {
   deleteById,
   findAllByFilter,
   getById,
-  count
+  count,
+  truncate,
 };

--- a/branch-be/src/dao/tallerDAO.spec.ts
+++ b/branch-be/src/dao/tallerDAO.spec.ts
@@ -1,179 +1,110 @@
 import { expect } from "chai";
-import sinon from "sinon";
 import tallerDAO from "./tallerDAO";
-import { TallerModel } from "../database/models";
-import {
-  CreateOptions,
-  DestroyOptions,
-  FindOptions,
-  Model,
-  Optional,
-  UpdateOptions,
-} from "sequelize";
-import { TallerAttributes, TallerCreationAttributes } from "../types";
+import { 
+  TallerCreationAttributes, TallerInstance 
+} from "../types";
+import { faker } from "@faker-js/faker";
 
-describe.skip("taller DAO unit testing", () => {
-  describe("list tallers functionality", () => {
-    let findAllStub: sinon.SinonStub<
-      [options?: FindOptions<any> | undefined],
-      Promise<Model<any, any>[]>
-    >;
-    beforeEach(() => {
-      findAllStub = sinon.stub(TallerModel, "findAll");
+describe("workshop DAO unit testing", () => {
+
+  let tallerCreated: TallerInstance;
+
+  describe("create workshop", ()=> {
+    it("must fail when try to  create an user with the minimum values", async ()=> {
+      const workshop: any = {
+        nombre: faker.company.name(),
+        identificacion: faker.string.numeric(10),
+        email: faker.internet.email(),
+        celular: faker.phone.number(),
+        estado: faker.helpers.arrayElement(["Registrado", "Pendiente"]),
+        telefono: faker.phone.number(),
+        logo: faker.image.url(),
+      };
+
+      await expect(tallerDAO.create(workshop)).to.eventually.be.rejectedWith("cannot be null");
+
     });
 
-    afterEach(() => {
-      findAllStub.restore();
-    });
+    it("must create a workshop", async ()=> {
+      const workshop1: TallerCreationAttributes = {
+        nombre: faker.company.name(),
+        identificacion: faker.string.numeric(10),
+        email: faker.internet.email(),
+        celular: faker.phone.number(),
+        estado: faker.helpers.arrayElement(["Registrado", "Pendiente"]),
+        direccion: faker.location.streetAddress(),
+        latitude: faker.location.latitude(),
+        longitud: faker.location.longitude(),
+        telefono: faker.phone.number(),
+        logo: faker.image.url(),
+      };
 
-    it("taller model findAll result must be equal to findAll function", async () => {
-      const mockList = [{ id: 1 }, { id: 1 }, { id: 1 }];
-      findAllStub.resolves(mockList as any);
-      const list = await tallerDAO.findAll();
+      const workshop2: TallerCreationAttributes = {
+        nombre: faker.company.name(),
+        identificacion: faker.string.numeric(10),
+        email: faker.internet.email(),
+        celular: faker.phone.number(),
+        estado: faker.helpers.arrayElement(["Registrado", "Pendiente"]),
+        direccion: faker.location.streetAddress(),
+        latitude: faker.location.latitude(),
+        longitud: faker.location.longitude(),
+        telefono: faker.phone.number(),
+        logo: faker.image.url(),
+      };
 
-      expect(list).to.have.lengthOf(mockList.length);
-    });
+      tallerCreated = await tallerDAO.create(workshop1);
 
-    it("taller model findAll function must be called", async () => {
-      findAllStub.resolves([]);
-      await tallerDAO.findAll();
-
-      expect(findAllStub.called).to.equal(true);
-      expect(findAllStub.callCount).to.equal(1);
-    });
-
-    it("when taller model findAll function fails error is thrown upper layer", async () => {
-      findAllStub.rejects(new Error("Error getting list of talleres"));
-      const stubCatch = sinon.spy();
-      const stubThen = sinon.spy();
-      await tallerDAO.findAll().then(stubThen).catch(stubCatch);
-
-      expect(stubCatch.called).to.equal(true);
-      expect(stubThen.called).to.equal(false);
-    });
-  });
-
-  describe("create taller functionality", () => {
-    let createStub: sinon.SinonStub<
-      [
-        values?: Optional<any, string> | undefined,
-        options?: CreateOptions<any> | undefined
-      ],
-      Promise<Model<any, any>>
-    >;
-
-    const creationMock: TallerCreationAttributes = {
-      nombre: "test 1",
-      identificacion: "1123455",
-      direccion: "Address Test",
-      latitude: 100,
-      longitud: 120,
-      celular: "32155452312",
-      telefono: "22453224556",
-      email: "test@test.com",
-      logo: "/logo/url",
-      estado: "Activo",
-    };
-
-    const result: TallerAttributes = {
-      ...creationMock,
-      IdTaller: 1,
-    };
-
-    before(() => {
-      createStub = sinon.stub(TallerModel, "create");
-    });
-
-    after(() => {
-      createStub.restore();
-    });
-
-    it("taller model create function must be called when taller is created", async () => {
-      createStub.resolves(result as any);
-
-      const taller = await tallerDAO.create(creationMock);
-
-      expect(createStub.called).to.equal(true);
-      expect(createStub.callCount).to.equal(1);
-
-      expect(taller).to.equal(result);
-    });
-
-    it("taller model create function must be called with specific params", async () => {
-      createStub.resolves(result as any);
-
-      await tallerDAO.create(creationMock);
-
-      expect(createStub.calledWith(creationMock)).to.equal(true);
+      expect(tallerCreated).to.have.property("IdTaller");
+      await expect(tallerDAO.create(workshop2)).to.eventually.have.property("IdTaller");
     });
   });
 
-  describe("delete taller functionality", () => {
-    let destroyStub: sinon.SinonStub<
-      [options?: DestroyOptions<any> | undefined],
-      Promise<number>
-    >;
-
-    beforeEach(() => {
-      destroyStub = sinon.stub(TallerModel, "destroy");
+  describe("get by id", ()=> {
+    it("must search the workshop by id", async()=> {
+      const workshop = await tallerDAO.getById(1);
+      expect(workshop).to.have.property("IdTaller");
     });
 
-    afterEach(() => {
-      destroyStub.restore();
-    });
-
-    it("tallerModel destroy function result must be equal to deleteBy function", async () => {
-      destroyStub.resolves(1);
-      const result = await tallerDAO.deleteById(1);
-      expect(result).to.equal(1);
-    });
-
-    it("tallerModel destroy function must be called when params is a number", async () => {
-      destroyStub.resolves(1);
-      await tallerDAO.deleteById(1);
-      expect(destroyStub.called).to.equal(true);
-      expect(destroyStub.callCount).to.equal(1);
+    it("must return null when the workshop is not found", async()=> {
+      await expect(tallerDAO.getById(-1)).to.eventually.be.null;
     });
   });
 
-  describe("update taller functionality", () => {
-    let updateStub: sinon.SinonStub<
-      [values: { [x: string]: any }, options: UpdateOptions<any>],
-      Promise<[affectedCount: number]>
-    >;
+  describe("update workshop", ()=> {
+    it("must return zero when id to update does not exist", async ()=> {
+      const updateResult = await tallerDAO.update(-1, {
+        identificacion: faker.string.numeric(10) 
+      });
 
-    const tallerToUpdate: Partial<TallerCreationAttributes> = {
-      direccion: "1111111",
-    };
-
-    const resultMock: [affectedCount: number] = [1];
-
-    beforeEach(() => {
-      updateStub = sinon.stub(TallerModel, "update");
+      expect(updateResult).to.have.length(1);
+      expect(updateResult[0]).to.be.equal(0);
     });
 
-    afterEach(() => {
-      updateStub.restore();
+    it("must return number of elements updated", async ()=> {
+      const [updateResult1, updateResult2] = await Promise.all([
+        tallerDAO.update(1, {
+          identificacion: faker.string.numeric(10) 
+        }),
+        tallerDAO.update(2, {
+          identificacion: faker.string.numeric(10),
+          estado: faker.helpers.arrayElement(["Registrado", "Pendiente"]),
+        })
+      ]);
+
+      expect(updateResult1).to.have.length(1);
+      expect(updateResult1[0]).to.be.equal(1);
+      expect(updateResult2).to.have.length(1);
+      expect(updateResult2[0]).to.be.equal(1);
+    });
+  });
+
+  describe("delete workshop", ()=> {
+    it("must return the number of items deleted by workshop id", async ()=> {
+      await expect(tallerDAO.deleteById(tallerCreated.IdTaller)).to.eventually.be.equal(1);
     });
 
-    it("tallerModel update function result must be equal to tallerDao update", async () => {
-      updateStub.resolves(resultMock);
-      const result = await tallerDAO.update(1, tallerToUpdate);
-
-      expect(result).to.equal(resultMock);
-    });
-
-    it("tallerModel update function must be called when params is a number", async () => {
-      updateStub.resolves(resultMock);
-      await tallerDAO.update(2, tallerToUpdate);
-      expect(updateStub.called).to.equal(true);
-      expect(updateStub.callCount).to.equal(1);
-    });
-
-    it("tallerModel update function must called once when param is an string", async () => {
-      updateStub.resolves(resultMock);
-      await tallerDAO.update(3, tallerToUpdate);
-      expect(updateStub.callCount).to.equal(1);
+    it("must return zero when workshop to delete does not exist", async ()=> {
+      await expect(tallerDAO.deleteById(-1)).to.eventually.be.equal(0);
     });
   });
 });

--- a/branch-be/src/dao/tallerDAO.ts
+++ b/branch-be/src/dao/tallerDAO.ts
@@ -3,13 +3,11 @@ import { TallerInstance, TallerCreationAttributes } from "../types";
 
 const getById = (
   IdTaller: number | string
-): Promise<TallerInstance | null> | undefined => {
-  return TallerModel.sequelize?.transaction(() => {
-    return TallerModel.findByPk(IdTaller, {
-      include: {
-        model: MecanicoModel,
-      },
-    });
+): Promise<TallerInstance | null> => {
+  return TallerModel.findByPk(IdTaller, {
+    include: {
+      model: MecanicoModel,
+    },
   });
 };
 
@@ -24,21 +22,15 @@ const create = (
 const update = (
   IdTaller: number,
   taller: Partial<TallerCreationAttributes>
-): Promise<[affectedCount: number]> | undefined => {
-  // Find all users
-  return TallerModel.sequelize?.transaction((t1) => {
-    return TallerModel.update(taller, {
-      where: { IdTaller },
-    });
+): Promise<[affectedCount: number]> => {
+  return TallerModel.update(taller, {
+    where: { IdTaller },
   });
 };
 
-const deleteById = (IdTaller: number): Promise<number> | undefined => {
-  // Find all users
-  return TallerModel.sequelize?.transaction(() => {
-    return TallerModel.destroy({
-      where: { IdTaller },
-    });
+const deleteById = (IdTaller: number): Promise<number> => {
+  return TallerModel.destroy({
+    where: { IdTaller },
   });
 };
 

--- a/branch-be/src/dao/userDAO.spec.ts
+++ b/branch-be/src/dao/userDAO.spec.ts
@@ -9,9 +9,10 @@ import usersDAO from "./usersDAO";
 import {
   Op,
 } from "sequelize";
-import { TallerCreationAttributes, UserCreationAttributes, VehiculoCreationAttributes } from "../types";
+import { TallerCreationAttributes, UserCreationAttributes, UserInstance, VehiculoCreationAttributes } from "../types";
 import vehiculoDAO from "./vehiculoDAO";
 import tallerDAO from "./tallerDAO";
+import citaDAO from "./citaDAO";
 
 describe("user DAO unit testing", () => {
 
@@ -32,7 +33,14 @@ describe("user DAO unit testing", () => {
     celular: faker.phone.number(),
     uid: faker.string.uuid()
   };
-  
+
+  let userCreated: UserInstance;
+
+  before(async ()=> {
+    await citaDAO.truncate();
+    await vehiculoDAO.truncate();
+    await usersDAO.truncate();
+  });
   
   describe("create user functionality", () => {
 
@@ -46,27 +54,20 @@ describe("user DAO unit testing", () => {
 
     it("must create the users in the database", async () => {
 
-      const user = await usersDAO.create(userMock);
+      userCreated = await usersDAO.create(userMock);
       const user2 = await usersDAO.create(userMock2);
       
-      expect(user).to.have.property("IdUsuario");
+      expect(userCreated).to.have.property("IdUsuario");
       expect(user2).to.have.property("IdUsuario");
     });
   });
 
   describe("get by id", () => {
     it("must return user by integer id", async () => {
-      const user = await usersDAO.getById(1);
+      const user = await usersDAO.getById(userCreated.IdUsuario);
 
       expect(user).to.have.property("IdUsuario");
-      expect(user?.IdUsuario).to.equal(1);
-    });
-
-    it("must return user by string id", async () => {
-      const user = await usersDAO.getById("2");
-
-      expect(user).to.have.property("IdUsuario");
-      expect(user?.IdUsuario).to.equal(2);
+      expect(user?.IdUsuario).to.equal(userCreated.IdUsuario);
     });
 
     it("must search an user by an nonexisting id", async () => {
@@ -90,7 +91,6 @@ describe("user DAO unit testing", () => {
       const user = await usersDAO.findOneByFilter({ email: userMock.email });
 
       expect(user).to.have.property("IdUsuario");
-      expect(user?.IdUsuario).to.equal(1);
     });
 
     it("must return one user by filter - 2", async () => {
@@ -101,7 +101,6 @@ describe("user DAO unit testing", () => {
       });
 
       expect(user).to.have.property("IdUsuario");
-      expect(user?.IdUsuario).to.equal(2);
     });
   });
 

--- a/branch-be/src/dao/usersDAO.ts
+++ b/branch-be/src/dao/usersDAO.ts
@@ -68,6 +68,10 @@ const update = (
   });
 };
 
+const truncate = async(): Promise<void> => {
+  await UserModel.truncate({ restartIdentity: true });
+};
+
 export default {
   getById,
   findAll,
@@ -76,6 +80,7 @@ export default {
   count,
   deleteById,
   update,
+  truncate,
 };
 
 

--- a/branch-be/src/dao/vehiculoDAO.ts
+++ b/branch-be/src/dao/vehiculoDAO.ts
@@ -122,6 +122,10 @@ const findPaginateByFilter = (
   return VehiculoModel.findAndCountAll(options);
 };
 
+const truncate = async(): Promise<void> => {
+  await VehiculoModel.truncate({ restartIdentity: true });
+};
+
 export default {
   create,
   update,
@@ -132,4 +136,5 @@ export default {
   getById,
   findAllByFilter,
   findPaginateByFilter,
+  truncate,
 };

--- a/branch-be/src/database/config/config.js
+++ b/branch-be/src/database/config/config.js
@@ -19,6 +19,10 @@ module.exports = {
   test: {
     dialect: "sqlite",
     storage: "database.sqlite3",
+    define: {
+      underscored: false,
+      freezeTableName: true,
+    },
   },
   production: {
     username: process.env.DBUSER,

--- a/branch-be/src/database/models/index.ts
+++ b/branch-be/src/database/models/index.ts
@@ -1,12 +1,6 @@
-// import fs from 'fs';
-// import path from 'path';
-import cls from "cls-hooked";
-import { Sequelize, Options, DataTypes } from "sequelize";
+import { DataTypes } from "sequelize";
+import sequelize from "./sequelize";
 
-// const basename = path.basename(__filename);
-const namespace = cls.createNamespace("my-very-own-namespace");
-const env: string = process.env.NODE_ENV || "development";
-import dbConfig from "../config/config";
 import {
   UserInstance,
   MarcaInstance,
@@ -24,27 +18,8 @@ import {
   ServicioVehiculoInstance,
 } from "../../types";
 // import { String } from "aws-sdk/clients/batch";
-import Debug from "debug";
+
 import moment from "moment";
-const debug = Debug("branch:server");
-
-const myConfig: Options = (dbConfig as any)[env];
-
-Sequelize.useCLS(namespace);
-
-debug("Connecting to dialect ::> ", myConfig.dialect);
-const sequelize = new Sequelize(myConfig);
-
-const testConnection = async () => {
-  try {
-    await sequelize.authenticate();
-    console.log("Connection has been established successfully.");
-  } catch (error) {
-    console.error("Unable to connect to the database:", error);
-  }
-};
-
-testConnection();
 
 const MarcaModel = sequelize.define<MarcaInstance>(
   "marca",
@@ -141,6 +116,59 @@ const TallerModel = sequelize.define<TallerInstance>("taller", {
   },
 }, {
   freezeTableName: true
+});
+
+const UserModel = sequelize.define<UserInstance>("usuarios", {
+  IdUsuario: {
+    type: DataTypes.INTEGER.UNSIGNED,
+    primaryKey: true,
+    autoIncrement: true,
+  },
+  firstName: {
+    type: DataTypes.STRING,
+    allowNull: true,
+  },
+  lastName: {
+    type: DataTypes.STRING,
+    // allowNull defaults to true
+  },
+  identificacion: {
+    type: DataTypes.STRING,
+    unique: true,
+    // allowNull defaults to true
+  },
+  email: {
+    type: DataTypes.STRING,
+    allowNull: false,
+    validate: {
+      isEmail: true,
+    },
+  },
+  uid: {
+    type: DataTypes.STRING(150),
+    allowNull: true,
+    unique: true,
+  },
+  celular: {
+    type: DataTypes.STRING,
+  },
+  tipoUsuario: {
+    type: DataTypes.ENUM("Cliente", "AdminTaller"),
+    allowNull: false,
+  },
+  estado: {
+    type: DataTypes.ENUM("Registrado", "Pendiente"),
+    allowNull: false,
+  },
+  IdTaller: {
+    type: DataTypes.INTEGER,
+  },
+  tokenCM: {
+    type: DataTypes.STRING,
+  },
+  typeDevice: {
+    type: DataTypes.STRING,
+  },
 });
 
 const VehiculoModel = sequelize.define<VehiculoInstance>("vehiculo", {
@@ -261,58 +289,6 @@ const CitaModel = sequelize.define<CitaInstance>("cita", {
   },
 });
 
-const UserModel = sequelize.define<UserInstance>("usuarios", {
-  IdUsuario: {
-    type: DataTypes.INTEGER.UNSIGNED,
-    primaryKey: true,
-    autoIncrement: true,
-  },
-  firstName: {
-    type: DataTypes.STRING,
-    allowNull: true,
-  },
-  lastName: {
-    type: DataTypes.STRING,
-    // allowNull defaults to true
-  },
-  identificacion: {
-    type: DataTypes.STRING,
-    unique: true,
-    // allowNull defaults to true
-  },
-  email: {
-    type: DataTypes.STRING,
-    allowNull: false,
-    validate: {
-      isEmail: true,
-    },
-  },
-  uid: {
-    type: DataTypes.STRING(150),
-    allowNull: true,
-  },
-  celular: {
-    type: DataTypes.STRING,
-  },
-  tipoUsuario: {
-    type: DataTypes.ENUM("Cliente", "AdminTaller"),
-    allowNull: false,
-  },
-  estado: {
-    type: DataTypes.ENUM("Registrado", "Pendiente"),
-    allowNull: false,
-  },
-  IdTaller: {
-    type: DataTypes.INTEGER,
-  },
-  tokenCM: {
-    type: DataTypes.STRING,
-  },
-  typeDevice: {
-    type: DataTypes.STRING,
-  },
-});
-
 const MecanicoModel = sequelize.define<MecanicoInstance>("mecanico", {
   IdMecanico: {
     type: DataTypes.INTEGER,
@@ -350,6 +326,8 @@ const MecanicoModel = sequelize.define<MecanicoInstance>("mecanico", {
       throw new Error("Do not try to set the `fullName` value!");
     },
   },
+}, {
+  freezeTableName: true
 });
 
 const MecanicoTallerModel = sequelize.define<MecanicoTallerInstance>(
@@ -368,7 +346,7 @@ const MecanicoTallerModel = sequelize.define<MecanicoTallerInstance>(
       },
     },
   },
-  { timestamps: false }
+  { timestamps: false, freezeTableName: true }
 );
 
 const OrdenModel = sequelize.define<OrdenInstance>("ordentrabajo", {
@@ -648,7 +626,7 @@ VehiculoModel.hasMany(CitaModel, {
 });
 
 VehiculoModel.belongsTo(UserModel, {
-  foreignKey:  "IdUsuario",
+  foreignKey: "IdUsuario",
   targetKey: "uid",
 });
 

--- a/branch-be/src/database/models/sequelize.ts
+++ b/branch-be/src/database/models/sequelize.ts
@@ -1,0 +1,28 @@
+import cls from "cls-hooked";
+import { Sequelize, Options } from "sequelize";
+import Debug from "debug";
+
+const namespace = cls.createNamespace("my-very-own-namespace");
+const env: string = process.env.NODE_ENV || "development";
+import dbConfig from "../config/config";
+
+const myConfig: Options = (dbConfig as any)[env];
+const debug = Debug("branch:server");
+
+Sequelize.useCLS(namespace);
+
+debug("Connecting to dialect ::> ", myConfig.dialect);
+const sequelize = new Sequelize(myConfig);
+
+const testConnection = async () => {
+  try {
+    await sequelize.authenticate();
+    console.log("Connection has been established successfully.");
+  } catch (error) {
+    console.error("Unable to connect to the database:", error);
+  }
+};
+
+testConnection();
+
+export default sequelize;

--- a/branch-be/src/socket/socket.ts
+++ b/branch-be/src/socket/socket.ts
@@ -46,7 +46,7 @@ interface ClientToServerEvents {
     callback: (result: { status: string; message: string }) => void
   ) => void;
   messaggetosomeone: (id: string, msg: InitialMessage) => void;
-  newcita: (data: { IdTaller: string; IdCita: string }) => void;
+  newcita: (data: { IdTaller: string; IdCita: number }) => void;
 }
 
 interface ServerToClientEvents {

--- a/branch-be/src/types.ts
+++ b/branch-be/src/types.ts
@@ -1,4 +1,4 @@
-import { Model, Optional } from "sequelize";
+import { CreationAttributes, CreationOptional, InferAttributes, InferCreationAttributes, Model, NonAttribute, Optional } from "sequelize";
 
 /** ****************
  Marca types
@@ -59,7 +59,7 @@ export interface UserFilter {
 }
 
 export interface UserAttributes {
-  IdUsuario: number;
+  IdUsuario: CreationOptional<number>;
   firstName: string;
   lastName?: string;
   identificacion?: string | null;
@@ -74,11 +74,11 @@ export interface UserAttributes {
   password?: string;
 }
 
-export type UserCreationAttributes = Optional<UserAttributes, "IdUsuario">
-
 export interface UserInstance
-  extends Model<UserAttributes, UserCreationAttributes>,
+  extends Model<InferAttributes<UserInstance>, InferCreationAttributes<UserInstance>>,
     UserAttributes {}
+
+export type UserCreationAttributes =  CreationAttributes<UserInstance> 
 
 /** ****************
  Cita types
@@ -86,11 +86,11 @@ export interface UserInstance
 export interface CitaAttributes {
   IdCita: number;
   IdTaller: number;
-  IdMecanico?: number;
+  IdMecanico?: number | null;
   IdVehiculo: number;
   fechaCita: Date;
   horaCita: number;
-  servicio?: string;
+  servicio?: string | null;
   estado: string;
   calificacion?: number;
   calificacionUsuario?: number;
@@ -99,7 +99,7 @@ export interface CitaAttributes {
   mecanico?: MecanicoAttributes;
 }
 
-export type CitaCreationAttributes = Optional<CitaAttributes, "IdCita">
+export type CitaCreationAttributes = Optional<CitaAttributes, "IdCita" | "vehiculo" | "taller" | "mecanico">
 
 export interface CitaRequestAttributes {
   IdTaller: number;
@@ -112,7 +112,7 @@ export interface CitaRequestAttributes {
 }
 
 export interface CalificaCitaRequest {
-  IdCita: string | number; //TODO: change function for one param with type
+  IdCita: number; //TODO: change function for one param with type
   calificacion?: number;
   calificacionUsuario?: number;
 }


### PR DESCRIPTION
- remove default sequelize transation of each function in tallerDAO and citaDAO, transactions must be only used where needed
- Use sqlite database for integrations tests
- Small tweaks to models definition
- Separate sequelize instance to a different module
