### PR TITLE
Fix error in add/update vehicle screens in app

### DIFF
--- a/branch-app/app/components/talleres/ListTalleres.tsx
+++ b/branch-app/app/components/talleres/ListTalleres.tsx
@@ -131,7 +131,6 @@ function Taller(props: any) {
           size="large"
           source={{
             uri: taller.logo,
-            // "https://s3.amazonaws.com/uifaces/faces/twitter/ladylexy/128.jpg",
           }}
         />
       </View>

--- a/branch-app/app/screens/Vehiculo/AgregarVehiculo.tsx
+++ b/branch-app/app/screens/Vehiculo/AgregarVehiculo.tsx
@@ -45,7 +45,7 @@ export default function AgregarVehiculo(
     formState: { errors },
   } = useForm<FormData>();
   const [showCalendar, setShowCalendar] = useState(false);
-  const [fechaCompra, setFechaCompra] = useState(new Date(1598051730000));
+  const [fechaCompra, setFechaCompra] = useState(new Date());
   const [referencia, setReferencia] = useState("");
   const [marca, setMarca] = useState("");
   const [urlFoto] = useState();

--- a/branch-app/app/screens/Vehiculo/EditarVehiculo.tsx
+++ b/branch-app/app/screens/Vehiculo/EditarVehiculo.tsx
@@ -28,7 +28,9 @@ export default function EditarVehiculo(
   const [marcas, setMarcas] = useState([]);
   const [showCalendar, setShowCalendar] = useState(false);
   const [fechaCompra, setFechaCompra] = useState(
-    vehiculo.fechaCompra ? vehiculo.fechaCompra : null
+    vehiculo.fechaCompra
+      ? Moment(vehiculo.fechaCompra, "YYYY-MM-DD").toDate()
+      : new Date()
   );
   const [referencias, setReferencias] = useState([]);
   const {
@@ -111,8 +113,7 @@ export default function EditarVehiculo(
       tipoVehiculo: vehiculo.tipoVehiculo,
       fotos: urlFoto ? [urlFoto] : [],
       color: data.color,
-      fechacompra: data.fechacompra,
-      fechaCompraText: Moment(data.fechacompra).format("d/MM/YYYY"),
+      fechaCompra: data.fechacompra,
       modelo: data.modelo,
     };
     fetch(URL_SERVICES + "vehiculo/update/" + vehiculo.IdVehiculo, {
@@ -306,7 +307,6 @@ export default function EditarVehiculo(
           keyboardType="number-pad"
           value={vehiculo.placa}
           containerStyle={styles.inputContainer}
-          disabled={true}
         />
 
         <Input
@@ -314,11 +314,12 @@ export default function EditarVehiculo(
           inputStyle={styles.input}
           label="Fecha compra"
           placeholder="Fecha compra"
-          editable={vehiculo.fechaCompra ? false : true}
+          editable={vehiculo.fechaCompra === null}
           containerStyle={styles.inputContainer}
-          disabled={vehiculo.fechaCompra ? true : false}
           onFocus={() => {
-            setShowCalendar(true);
+            if (vehiculo.fechaCompra === null) {
+              setShowCalendar(true);
+            }
           }}
           value={fechaCompra ? Moment(fechaCompra).format("DD/MM/YYYY") : ""}
         />
@@ -337,8 +338,10 @@ export default function EditarVehiculo(
             locale="es-ES"
             onChange={(event, selectedDate) => {
               setShowCalendar(Platform.OS === "ios" ? true : false);
-              setValue("fechacompra", selectedDate);
-              setFechaCompra(selectedDate!);
+              if (selectedDate) {
+                setValue("fechacompra", selectedDate);
+                setFechaCompra(selectedDate);
+              }
             }}
           />
         )}

--- a/branch-app/data/data.tsx
+++ b/branch-app/data/data.tsx
@@ -35,6 +35,15 @@ const years = [
   {
     value: "2021",
   },
+  {
+    value: "2022",
+  },
+  {
+    value: "2023",
+  },
+  {
+    value: "2024",
+  },
 ];
 
 const services = [

--- a/branch-be/src/controller/fileController.ts
+++ b/branch-be/src/controller/fileController.ts
@@ -13,10 +13,7 @@ const bucketName = process.env.BUCKET_MEDIA_NAME || "branchmedia2";
 const s3 = new AWS.S3(awsConfig);
 
 const signedS3 = (req: Request, res: Response) => {
-  //let file = req.body;
-  //let paramsss = req.params;
   console.log("Peticion recibida ::::>", req.query);
-  //console.log('Peticion recibida 2::::>', paramsss);
   const unicocode = moment().format("MMDDYYYYHHMMSS");
   const key = unicocode + req.query.filename;
   const bucket = bucketName;


### PR DESCRIPTION
- Set the current date as default date in the add vehicle screen
- Set current date as default date in the update vehicle screen, the null value was generating errors to open the date picker
- Only open the piker in the update vehicle screen when the date has not been set